### PR TITLE
Fixing nil error when working with some windows.

### DIFF
--- a/exwm-mff.el
+++ b/exwm-mff.el
@@ -88,16 +88,18 @@
 
 (defun exwm-mff--contains-pointer? (window)
   "Return non-NIL when the mouse pointer is within WINDOW."
-  (with-slots (win-x win-y)
-      (xcb:+request-unchecked+reply exwm--connection
-          (make-instance 'xcb:QueryPointer
-                         :window (frame-parameter (selected-frame)
-                                                  'exwm-outer-id)))
-    (pcase (window-absolute-pixel-edges window)
-      (`(,left ,top ,right ,bottom)
-       (and
-        (<= left win-x right)
-        (<= top win-y bottom))))))
+  (let ((fp (frame-parameter (selected-frame) 'exwm-outer-id)))
+    (if fp
+        (with-slots (win-x win-y)
+            (xcb:+request-unchecked+reply exwm--connection
+                (make-instance 'xcb:QueryPointer
+                               :window fp))
+          (pcase (window-absolute-pixel-edges window)
+            (`(,left ,top ,right ,bottom)
+             (and
+              (<= left win-x right)
+              (<= top win-y bottom)))))
+      t)))
 
 (defun exwm-mff--warp-to (window-id x y)
   "Warp the mouse pointer WINDOW-ID, position X, Y."


### PR DESCRIPTION
I use zoom (alot) now that we are all working from home. I can't use exwm-mff
with zoom because when I try to launch it some window comes up at nil when
detecting if the mouse is in the window.

I have modified exwm-mff--contains-pointer? to return t if the window is nil.
This prevents both trying to query the windows location, and trying to move it.
Once again allowing me to use exwm-mff with zoom.